### PR TITLE
Compatibility Drupal 11 alpha1 + Drush 13 beta1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,11 @@ RUN set -x && apt-get update && \
     composer create-project drupal/recommended-project:$DRUPAL_VERSION $DRUPAL_COMPOSER_ROOT \
   ) && \
   cd $DRUPAL_COMPOSER_ROOT && \
-  composer require drush/drush || \
+  composer require drush/drush --with-all-dependencies || \
 # Try drush 13.x-dev if the above fails.
-  composer require drush/drush:13.x-dev || \
+  composer require drush/drush:13.x@beta chi-teck/drupal-code-generator:4.x-dev --with-all-dependencies || \
 # Try drush 11.x-dev if the above fails.
-  composer require drush/drush:11.x-dev && \
+  composer require drush/drush:11.x-dev --with-all-dependencies && \
   mkdir -p $DRUPAL_DOCROOT/sites/default/files && \
   chgrp www-data $DRUPAL_DOCROOT/sites/default/files && \
   chmod 2775 $DRUPAL_DOCROOT/sites/default/files && \


### PR DESCRIPTION
Would fix https://github.com/q0rban/tugboat-drupal/issues/12, by upgrading chi-teck/drupal-code-generator to 4.x-dev too, but not 100% sure this should be used at all.